### PR TITLE
fix: [Patches] NRE when reading locked slots file

### DIFF
--- a/Source/QuickStack.cs
+++ b/Source/QuickStack.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using HarmonyLib;
 using UnityEngine;
 
@@ -24,7 +25,7 @@ internal class QuickStack
 
     public static string lockedSlotsFile()
     {
-        return GameIO.GetPlayerDataDir() + "/" + GameManager.Instance.persistentLocalPlayer.UserIdentifier + ".qsls";
+        return Path.Combine(GameIO.GetPlayerDataDir(), GameManager.Instance.persistentLocalPlayer.UserIdentifier + ".qsls");
     }
 
     public static Dictionary<TileEntity, int> GetOpenedTiles()


### PR DESCRIPTION
## Purpose
My game was not loading locked slots.

## Changes
Falling back to using what the file writer is using to store the int, even if it may be incorrect. The combo box is not referenced anywhere else in code.
This adds logging around read/writing locked slots file and makes sure the file path is valid.

## Notes
I have other commits in the works so I'm not pushing a built .dll yet