### PR TITLE
fix: use library-provided entityID, not client's

### DIFF
--- a/Source/NetPackages/NetPackageFindOpenableContainers.cs
+++ b/Source/NetPackages/NetPackageFindOpenableContainers.cs
@@ -30,7 +30,6 @@ class NetPackageFindOpenableContainers : NetPackage
         {
             return;
         }
-
         if (!_world.Players.dict.TryGetValue(playerEntityId, out var playerEntity) || playerEntity == null)
         {
             return;
@@ -69,7 +68,10 @@ class NetPackageFindOpenableContainers : NetPackage
 
     public override void read(PooledBinaryReader _reader)
     {
-        playerEntityId = _reader.ReadInt32();
+        // ignore entity ID sent by client
+        _ = _reader.ReadInt32();
+        // use the NetPackage-provided one instead
+        playerEntityId = Sender.entityId;
         type = (QuickStackType)_reader.ReadByte();
     }
 


### PR DESCRIPTION
## Purpose
It is error-prone and perhaps incorrect to send a player's entityID in a client-to-server NetPackage. 

## Changes
Without changing the data structure, the server discards the received entity ID and uses the one provided by `sender.entityId`. Doing it this way makes it so the server may be patched while maintaining compatibility with older mod versions.